### PR TITLE
Expanding assigments to noise during export to new project (Discovery step)

### DIFF
--- a/asoid/utils/motionenergy.py
+++ b/asoid/utils/motionenergy.py
@@ -155,9 +155,7 @@ def animate_blobs(arr, filename, outlines:dict, include_dots = False, center_shi
             #convert into list of tuples (cv2 input)
             #opencv does not take float, so convert points into int for px values
             bp_points1 = frame_coords.astype(int)
-            #pts = [(50, 50), (300, 190), (400, 10)]
             bp_points2 = list((map(tuple, bp_points1)))
-            #cv2.polylines(img, np.array([pts]), True, RED, 5)
             cv2.fillPoly(img, np.array([bp_points2]), color= poly_color)
             if include_dots:
                 for bp in bp_points2:
@@ -216,15 +214,6 @@ class MotionEnergyMachine:
 
     def select_outline(self):
         "Allows GUI selection of polygons made up by bodyparts as corners for blob animation"
-        # available colors
-        colors = dict(cyan = (255, 255, 0)
-                      , magenta = (255, 0, 255)
-                      , red = (255, 0,0)
-                      , lime = (0,255,0)
-                      , blue = (0,0,255)
-                      , yellow = (255, 255, 0)
-                      , white = (255, 255, 255)
-                      )
 
         poly_count = st.number_input("Number of Polygons"
                                      , help= POLY_COUNT_HELP
@@ -252,11 +241,13 @@ class MotionEnergyMachine:
                                                  , help = "If you want to change the color, just click on the color picker again."
                                                           " If you want to use the same color again, just copy the hex code and paste it into another color picker."
                                                           )
-
-
+            #convert to rgb from streamlit hex code
+            rgb_color = getcolor(color_selection, "RGB")
+            #convert to bgr for opencv (using np.array.tolist() first to convert to tuple to convert to int instead of int64)
+            bgr_color = tuple(np.array(rgb_color, dtype= int)[::-1].tolist())
 
             outline_dict[polygon_key] = dict(order = poly_selection
-                                             , color = getcolor(color_selection, "RGB")
+                                             , color = bgr_color
                                             )
 
         #translate selected keypoints into indices
@@ -568,8 +559,10 @@ class MotionEnergyMachine:
                     try:
                         self.create_blob_animation(sub_selected_classes, outline_dict, ref_origin_idx, ref_rot_idxs)
                         animation_info_box.info("Ready for motion energy calculcation.")
-                    except:
+                    except Exception as e:
                         animation_info_box.error("Enter required parameters first.")
+                        #print error for reporting
+                        print(e)
 
 
         with motion_container:


### PR DESCRIPTION
Previously hdbscan assignments were directly split into new groups when exporting to a new project.
This can lead to the "noise" being reassigned to the original class (even though noise contains instances of the other sub-classes).

Solution:
 In line with B-SOiD, we train a Randomforest on the assignments and predict the sub-class identity afterward before assigning new labels to the data set. This leads to reassigning each label of the selected class to the predicted class by the new model.
The predicted labels are then exported with a subselection of sub-classes of interest during the save process. 

Thoughts:
Although not entirely intuitive for users, this is the only way to reliably export clusters as we do not trust the assignments for individual identities but instead use the clustering as an orientation.

@runninghsus Pls review if this is the intended behavior from B-SOiD