### PR TITLE
Update requirements.txt to specify streamlit version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.27.0
+streamlit==1.36.0
 streamlit_option_menu
 opencv-python
 hydralit


### PR DESCRIPTION
Hi, I came across an issue when trying to install asoid. Using the latest streamlit (1.40.1) caused an error upon launching the app. Using streamlit==1.36.0 fixed the issue.